### PR TITLE
Add domain parameter to Shopify helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,9 +6,8 @@ from openai import OpenAI
 
 load_dotenv()
 
-def get_shopify_products():
+def get_shopify_products(shop_domain: str):
 
-    shop_domain = os.getenv("SHOP_DOMAIN")
     storefront_token = os.getenv("SHOPIFY_STOREFRONT_TOKEN")
     url = f"https://{shop_domain}/api/2023-10/graphql.json"
 


### PR DESCRIPTION
## Summary
- load dotenv config
- add `shop_domain` argument to `get_shopify_products`
- ensure `chat` passes domain
- add newline at end of file

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d7389090c83328b667e5ebec661da