### PR TITLE
Finalize Shopify-compatible deployment of SEEP chatbot on Render.

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,28 +1,45 @@
 import os
-from flask import Flask, request, jsonify, render_template, url_for
+from flask import (
+    Flask,
+    request,
+    jsonify,
+    render_template,
+    redirect,
+    url_for,
+)
 import requests
 from dotenv import load_dotenv
 from openai import OpenAI
 
 load_dotenv()
 
-def get_shopify_products(shop_domain=None):
-    shop_domain = shop_domain or os.getenv("SHOP_DOMAIN")
-    if not shop_domain:
-        return "Store domain not configured."
+app = Flask(__name__, template_folder="templates")
 
-    storefront_token = os.getenv("SHOPIFY_STOREFRONT_TOKEN")
-    url = f"https://{shop_domain}/api/2023-10/graphql.json"
-    
-    # continue with your logic to make request...
-    storefront_token = os.getenv("SHOPIFY_STOREFRONT_TOKEN")
-    url = f"https://{shop_domain}/api/2023-10/graphql.json"
+# Configuration stored in memory so store owners can provide values
+user_config = {
+    "bot_name": os.getenv("BOT_NAME", "Seep"),
+    "shopify_domain": os.getenv("SHOP_DOMAIN", ""),
+    "shopify_token": os.getenv("SHOPIFY_STOREFRONT_TOKEN", ""),
+}
 
+client = OpenAI(
+    api_key=os.getenv("OPENROUTER_API_KEY"),
+    base_url="https://openrouter.ai/api/v1",
+)
+
+
+def get_shopify_products(domain: str | None = None, token: str | None = None) -> str:
+    """Fetch a few products from Shopify. Return human-readable summary."""
+    shop_domain = domain or user_config.get("shopify_domain")
+    storefront_token = token or user_config.get("shopify_token")
+    if not shop_domain or not storefront_token:
+        return "Store info not configured."
+
+    url = f"https://{shop_domain}/api/2023-10/graphql.json"
     headers = {
         "X-Shopify-Storefront-Access-Token": storefront_token,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
-
     query = """
     {
       products(first: 5) {
@@ -30,93 +47,88 @@ def get_shopify_products(shop_domain=None):
           node {
             title
             description
-            images(first: 1) {
-              edges {
-                node {
-                  src
-                }
-              }
-            }
+            images(first: 1) { edges { node { src } } }
           }
         }
       }
     }
     """
-
-    response = requests.post(url, json={"query": query}, headers=headers)
-    data = response.json()
-
-    if "data" in data:
-        products = data["data"]["products"]["edges"]
-        result = ""
-        for p in products:
-            title = p["node"]["title"]
-            description = p["node"]["description"]
-            image = (
-                p["node"]["images"]["edges"][0]["node"]["src"]
-                if p["node"]["images"]["edges"]
-                else "No image"
-            )
-            result += f"Title: {title}\nDescription: {description}\nImage: {image}\n\n"
-        return result.strip()
-    return "No products found."
-
-app = Flask(__name__, template_folder="templates")
-client = OpenAI(
-    api_key=os.getenv("OPENROUTER_API_KEY"),
-    base_url="https://openrouter.ai/api/v1"
-)
-
-@app.route("/", methods=["GET", "HEAD"])
-def home():
-    return render_template(
-        "index.html",
-        bot_name=os.getenv("BOT_NAME", "Seep"),
-        shop_domain=os.getenv("SHOP_DOMAIN", "")
-    )
-
-@app.route("/chat", methods=["POST"])
-def chat():
-    data = request.json
-    user_input = data.get("prompt", "")
-    shop_domain = data.get("shop_domain", "")
-    bot_name = os.getenv("BOT_NAME", "Seep")
-
     try:
-        # Fetch products using the shop domain provided
-        product_info = get_shopify_products(shop_domain)
+        resp = requests.post(url, json={"query": query}, headers=headers, timeout=10)
+        data = resp.json()
+    except Exception:
+        return "Could not fetch products."
 
-        system_msg = f"You are {bot_name}, a smart, witty assistant for a Shopify store. Here's what's in the store:\n{product_info}\n\nAnswer in clear, human-like text with no markdown, code, or links."
+    products = data.get("data", {}).get("products", {}).get("edges", [])
+    if not products:
+        return "No products found."
 
-        response = client.chat.completions.create(
-            model="deepseek/deepseek-chat-v3-0324:free",
-            messages=[
-                {"role": "system", "content": system_msg},
-                {"role": "user", "content": user_input}
-            ]
+    result = []
+    for p in products:
+        node = p.get("node", {})
+        title = node.get("title", "")
+        description = node.get("description", "")
+        images = node.get("images", {}).get("edges", [])
+        image = images[0]["node"].get("src") if images else "No image"
+        result.append(
+            f"Title: {title}\nDescription: {description}\nImage: {image}"
         )
+    return "\n\n".join(result)
 
-        reply = response.choices[0].message.content
-        return jsonify({"reply": reply})
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+@app.route("/health", methods=["GET"])
+def health() -> tuple[str, int]:
+    return "OK", 200
 
-    # In-memory config (will reset every server restart)
-user_config = {
-        "bot_name": "Seep",
-        "shopify_domain": "",
-        "shopify_token": ""
-    }
 
-@app.route("/setup", methods=["GET", "POST"])
+@app.route("/", methods=["GET", "POST"])
 def setup():
     if request.method == "POST":
-        user_config["bot_name"] = request.form.get("bot_name", "Seep")
-        user_config["shopify_domain"] = request.form.get("shopify_domain", "")
-        user_config["shopify_token"] = request.form.get("shopify_token", "")
-        return redirect(url_for("home"))
-    return render_template("setup.html")
+        user_config["bot_name"] = request.form.get("bot_name", user_config["bot_name"])
+        user_config["shopify_domain"] = request.form.get("shopify_domain", user_config["shopify_domain"])
+        token = request.form.get("shopify_token")
+        if token:
+            user_config["shopify_token"] = token
+        return redirect(url_for("chat", bot_name=user_config["bot_name"], shop_domain=user_config["shopify_domain"]))
+
+    return render_template(
+        "setup.html",
+        bot_name=user_config["bot_name"],
+        shopify_domain=user_config["shopify_domain"],
+        shopify_token=user_config["shopify_token"],
+    )
+
+
+@app.route("/chat", methods=["GET", "POST"])
+def chat():
+    if request.method == "POST":
+        data = request.get_json(force=True)
+        user_input = data.get("prompt", "")
+        shop_domain = data.get("shop_domain") or user_config.get("shopify_domain")
+        bot_name = user_config.get("bot_name", "Seep")
+        token = user_config.get("shopify_token")
+
+        product_info = get_shopify_products(shop_domain, token)
+        system_msg = (
+            f"You are {bot_name}, a smart, witty assistant for a Shopify store. "
+            f"Here's what's in the store:\n{product_info}\n\n"
+            "Answer in clear, human-like text with no markdown, code, or links."
+        )
+        try:
+            resp = client.chat.completions.create(
+                model="deepseek/deepseek-chat-v3-0324:free",
+                messages=[{"role": "system", "content": system_msg}, {"role": "user", "content": user_input}],
+            )
+            reply = resp.choices[0].message.content
+            return jsonify({"reply": reply})
+        except Exception as exc:
+            return jsonify({"error": str(exc)}), 500
+
+    # GET request: render UI
+    bot_name = request.args.get("bot_name") or user_config.get("bot_name", "Seep")
+    shop_domain = request.args.get("shop_domain") or user_config.get("shopify_domain", "")
+    return render_template("index.html", bot_name=bot_name, shop_domain=shop_domain)
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=int(os.getenv("PORT", 10000)))

--- a/static/seep.js
+++ b/static/seep.js
@@ -1,9 +1,13 @@
 const msgs = document.getElementById("msgs");
-const botName = CONFIG.bot_name;
-const shopifyDomain = CONFIG.shopify_domain;
+const input = document.getElementById("txt");
+
+let botName = CONFIG.bot_name || sessionStorage.getItem("bot_name") || "Seep";
+let shopifyDomain = CONFIG.shopify_domain || sessionStorage.getItem("shopify_domain") || "";
+
+sessionStorage.setItem("bot_name", botName);
+sessionStorage.setItem("shopify_domain", shopifyDomain);
 
 async function send() {
-  const input = document.getElementById("txt");
   const text = input.value.trim();
   if (!text) return;
 
@@ -29,6 +33,14 @@ async function send() {
     append("bot", "Error talking to the server.");
   }
 }
+
+input.addEventListener("keyup", (e) => {
+  if (e.key === "Enter") {
+    send();
+  }
+});
+
+window.send = send;
 
 function append(sender, text) {
   const div = document.createElement("div");

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -41,13 +41,13 @@
     <h2>Configure Your Chatbot</h2>
 
     <label for="bot_name">Chatbot Name:</label>
-    <input type="text" id="bot_name" name="bot_name" placeholder="e.g. Seep" required>
+    <input type="text" id="bot_name" name="bot_name" placeholder="e.g. Seep" value="{{ bot_name }}" required>
 
     <label for="shopify_domain">Shopify Domain:</label>
-    <input type="text" id="shopify_domain" name="shopify_domain" placeholder="yourshop.myshopify.com" required>
+    <input type="text" id="shopify_domain" name="shopify_domain" placeholder="yourshop.myshopify.com" value="{{ shopify_domain }}" required>
 
     <label for="shopify_token">Storefront Access Token:</label>
-    <input type="text" id="shopify_token" name="shopify_token" placeholder="Paste token here..." required>
+    <input type="text" id="shopify_token" name="shopify_token" placeholder="Paste token here..." value="{{ shopify_token }}">
 
     <input type="submit" value="Save & Launch">
   </form>


### PR DESCRIPTION
## Summary
- clean up configuration storage and routes
- add `/health` endpoint for Render
- render setup form at root and use query params for chat page
- improve product fetching resiliency
- enhance frontend JS with enter-key submit and sessionStorage

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dea05503c8332b8031729836fd80d