### PR TITLE
Fix: add setuptools requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=58.0.0
 absl-py==2.1.0
 annotated-types==0.7.0
 anyio==4.9.0


### PR DESCRIPTION
## Summary
- add `setuptools>=58.0.0` to requirements for Render builds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e7f5ada10833294769de9c640e3d4