### PR TITLE
fix: render build compatibility (setuptools + python version)

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,2 @@
-python-3.11
+python-3.11.8
 


### PR DESCRIPTION
## Summary
- ensure deployment uses Python 3.11.8

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb7c289d883329568300e332c660f