### PR TITLE
Update requirements to upgrade packaging tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-setuptools>=58.0.0
+pip>=23.0
+setuptools>=65.0
+wheel
 absl-py==2.1.0
 annotated-types==0.7.0
 anyio==4.9.0


### PR DESCRIPTION
## Summary
- ensure `pip`, `setuptools`, and `wheel` are listed at the start of `requirements.txt`

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ebf3d5d388332afe910e1f81285b7