### PR TITLE
Fix OpenAI client initialization for latest SDK

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for, s
 import requests
 from dotenv import load_dotenv
 from openai import OpenAI
+import httpx
 
 load_dotenv()
 
@@ -23,10 +24,19 @@ def get_config() -> dict:
     }
 
 
-client = OpenAI(
-    api_key=os.getenv("OPENROUTER_API_KEY"),
-    base_url="https://openrouter.ai/api/v1",
-)
+_proxy = os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY")
+if _proxy:
+    http_client = httpx.Client(proxies=_proxy)
+    client = OpenAI(
+        api_key=os.getenv("OPENROUTER_API_KEY"),
+        base_url="https://openrouter.ai/api/v1",
+        http_client=http_client,
+    )
+else:
+    client = OpenAI(
+        api_key=os.getenv("OPENROUTER_API_KEY"),
+        base_url="https://openrouter.ai/api/v1",
+    )
 
 
 def get_shopify_products(domain: str | None = None, token: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- configure HTTP proxy via httpx instead of using unsupported `proxies` argument
- adjust OpenAI client initialization

## Testing
- `python -m py_compile app.py`
- `bash build.sh` *(fails: cannot access pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_684f3dc5d56883329bbf137b233235d0