### PR TITLE
Improve UI with polished templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,16 +169,26 @@ def setup() -> str:
         domain = request.form.get("shopify_domain", "").strip()
         token = request.form.get("shopify_token", "").strip()
         if not bot_name or not domain:
-            cfg = {"bot_name": bot_name or DEFAULT_BOT,
-                   "shopify_domain": domain,
-                   "shopify_token": token}
+            cfg = {
+                "bot_name": bot_name or DEFAULT_BOT,
+                "shopify_domain": domain,
+                "shopify_token": token,
+            }
             error = "Bot name and Shopify domain are required."
             return render_template("setup.html", error=error, **cfg)
+
         session["bot_name"] = bot_name
         session["shopify_domain"] = domain
         if token:
             session["shopify_token"] = token
-        return redirect(url_for("index"))
+
+        return render_template(
+            "setup.html",
+            bot_name=bot_name,
+            shopify_domain=domain,
+            shopify_token=token,
+            success=True,
+        )
 
     cfg = get_config()
     return render_template(

--- a/templates/billing_select.html
+++ b/templates/billing_select.html
@@ -5,13 +5,29 @@
   <title>Choose a SEEP Plan</title>
   <style>
     body {
-      font-family: Arial, sans-serif;
       margin: 0;
-      padding: 40px 20px;
+      padding: 20px;
+      padding-top: 60px;
+      font-family: Arial, sans-serif;
       background: linear-gradient(to bottom right, #f5f7fa, #e4ecf4);
     }
+    .branding {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 20px;
+      background: #005b96;
+      color: #fff;
+      font-weight: bold;
+    }
+    .branding a { color: #fff; text-decoration: none; }
     h1, h2 {
       text-align: center;
+      margin-top: 60px;
     }
     .error {
       color: red;
@@ -26,6 +42,10 @@
       max-width: 1000px;
       margin: auto;
     }
+    @keyframes fadein {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: none; }
+    }
     .plan {
       background: #fff;
       padding: 20px;
@@ -37,6 +57,7 @@
       display: flex;
       flex-direction: column;
       position: relative;
+      animation: fadein 0.5s ease forwards;
     }
     .badge {
       position: absolute;
@@ -65,17 +86,23 @@
       padding: 10px;
       border-radius: 5px;
       cursor: pointer;
+      transition: background 0.3s;
     }
     .plan button:hover {
       background: #00487c;
     }
-  </style>
+</style>
 </head>
 <body>
+  <div class="branding">
+    <span>SEEP Assistant</span>
+    <a href="#">Help</a>
+  </div>
   {% if message %}
     <div class="error">{{ message }}</div>
   {% endif %}
-  <h1>Choose a SEEP Plan</h1>
+  <h1>SEEP Assistant</h1>
+  <h2>Choose a SEEP Plan</h2>
   <h2>Choose a flexible plan. Save more with longer commitments.</h2>
   {% if active and current_plan in plans %}
     <p style="text-align:center;"><strong>Current Plan:</strong> {{ plans[current_plan].name }}</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,17 +7,32 @@
   <style>
     body {
       margin: 0;
-      padding: 0;
+      padding: 20px;
+      padding-top: 60px;
       font-family: Arial, sans-serif;
     }
+    .branding {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 20px;
+      background: #005b96;
+      color: #fff;
+      font-weight: bold;
+    }
+    .branding a { color: #fff; text-decoration: none; }
     .chatbot {
       position: fixed;
       bottom: 0;
       right: 0;
       left: 0;
-      margin: 0 auto 10px;
-      max-width: 400px;
-      width: 100%;
+      margin: 0 auto 20px;
+      max-width: 600px;
+      width: calc(100% - 20px);
       background-color: white;
       border: 1px solid #ccc;
       border-radius: 10px;
@@ -71,17 +86,26 @@
       background: #005b96;
       color: #fff;
       padding: 0 16px;
+      cursor: pointer;
+      transition: background 0.3s;
+    }
+    .input-area button:hover {
+      background: #00487c;
     }
     .spinner {
       text-align: center;
       padding: 8px;
       display: none;
     }
-  </style>
+</style>
 </head>
 <body>
+  <div class="branding">
+    <span>SEEP Assistant</span>
+    <a href="#">Help</a>
+  </div>
   <div class="chatbot">
-    <div class="header">{{ bot_name }}</div>
+    <div class="header">Chatting with {{ bot_name }}</div>
     <div class="messages" id="msgs"></div>
     <div id="spinner" class="spinner">Loading...</div>
     <div class="input-area">

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -5,13 +5,30 @@
   <title>Bot Setup</title>
   <style>
     body {
+      margin: 0;
+      padding: 20px;
+      padding-top: 60px;
+      font-family: Arial, sans-serif;
       display: flex;
       justify-content: center;
       align-items: center;
       min-height: 100vh;
-      font-family: Arial, sans-serif;
       background: #f5f5f5;
     }
+    .branding {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 20px;
+      background: #005b96;
+      color: #fff;
+      font-weight: bold;
+    }
+    .branding a { color: #fff; text-decoration: none; }
     form {
       background: #fff;
       padding: 20px;
@@ -20,12 +37,16 @@
       width: 100%;
       max-width: 400px;
     }
+    label {
+      margin-top: 10px;
+      display: block;
+    }
     input[type="text"],
     input[type="password"],
     button {
       width: 100%;
       padding: 10px;
-      margin-top: 10px;
+      margin-top: 5px;
       font-size: 16px;
       border: 1px solid #ccc;
       border-radius: 5px;
@@ -36,16 +57,35 @@
       color: white;
       border: none;
       cursor: pointer;
+      font-size: 18px;
+      transition: background 0.3s;
     }
     button:hover {
       background: #00487c;
     }
-  </style>
+    .message {
+      margin-bottom: 15px;
+      text-align: center;
+    }
+</style>
+{% if success %}
+  <meta http-equiv="refresh" content="2; url={{ url_for('index') }}">
+{% endif %}
 </head>
 <body>
+  <div class="branding">
+    <span>SEEP Assistant</span>
+    <a href="#">Help</a>
+  </div>
 
   <form method="POST">
     <h2>Configure Your Chatbot</h2>
+    {% if error %}
+      <div class="message" style="color:red;">{{ error }}</div>
+    {% endif %}
+    {% if success %}
+      <div class="message">✅ Setup saved! Redirecting...</div>
+    {% endif %}
 
     <label for="bot_name">Chatbot Name:</label>
     <input type="text" id="bot_name" name="bot_name" placeholder="e.g. SEEP" value="{{ bot_name }}" required>


### PR DESCRIPTION
## Summary
- refine subscription page with branding header and fade-in plan cards
- center setup form and show success message before redirect
- refresh chat page layout with branding and responsive design
- allow setup page to display success notice

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6850713dd8e0833292763e5e70f07efb