### PR TITLE
Add sandbox attribute for storefront chat iframe

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,6 +309,7 @@ def widget_js() -> Response:
   frame.style.border = 'none';
   frame.style.width = '100%';
   frame.style.height = '100%';
+  frame.setAttribute('sandbox', 'allow-scripts allow-same-origin');
   panel.appendChild(frame);
 
   bubble.addEventListener('click', function() {{


### PR DESCRIPTION
## Summary
- load chat widget iframe with sandbox attribute for extra security

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68507a4aca888332bd74efe91e84354e