### PR TITLE
Add embed instructions page and redirect after setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,13 +183,7 @@ def setup() -> str:
         if token:
             session["shopify_token"] = token
 
-        return render_template(
-            "setup.html",
-            bot_name=bot_name,
-            shopify_domain=domain,
-            shopify_token=token,
-            success=True,
-        )
+        return redirect(url_for("embed_instructions"))
 
     cfg = get_config()
     return render_template(
@@ -198,6 +192,17 @@ def setup() -> str:
         shopify_domain=cfg["shopify_domain"],
         shopify_token=cfg["shopify_token"],
         error=None,
+    )
+
+
+@app.route("/embed-instructions")
+@require_access
+def embed_instructions() -> str:
+    """Show instructions for embedding the widget."""
+    cfg = get_config()
+    return render_template(
+        "embed_instructions.html",
+        shopify_domain=cfg["shopify_domain"],
     )
 
 

--- a/templates/embed_instructions.html
+++ b/templates/embed_instructions.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Embed Instructions</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: #f5f5f5;
+      font-family: Arial, sans-serif;
+      text-align: center;
+    }
+    .box {
+      background: #fff;
+      padding: 20px;
+      border-radius: 10px;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+      max-width: 600px;
+      width: 100%;
+    }
+    code {
+      display: block;
+      background: #eee;
+      padding: 10px;
+      border-radius: 5px;
+      font-family: monospace;
+      word-break: break-all;
+    }
+    button {
+      margin-top: 10px;
+      padding: 8px 16px;
+      background: #005b96;
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+    button:hover { background: #00487c; }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>🎉 Setup Complete</h1>
+    <p>Paste this into your Shopify <code>theme.liquid</code> file before &lt;/body&gt;:</p>
+    <code id="snippet">&lt;script src="https://noble-server.onrender.com/widget.js?shop={{ shopify_domain }}" async&gt;&lt;/script&gt;</code>
+    <button onclick="copy()">Copy to Clipboard</button>
+  </div>
+  <script>
+    function copy() {
+      const text = document.getElementById('snippet').innerText;
+      navigator.clipboard.writeText(text);
+    }
+  </script>
+</body>
+</html>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -68,9 +68,6 @@
       text-align: center;
     }
 </style>
-{% if success %}
-  <meta http-equiv="refresh" content="2; url={{ url_for('index') }}">
-{% endif %}
 </head>
 <body>
   <div class="branding">
@@ -83,9 +80,7 @@
     {% if error %}
       <div class="message" style="color:red;">{{ error }}</div>
     {% endif %}
-    {% if success %}
-      <div class="message">✅ Setup saved! Redirecting...</div>
-    {% endif %}
+
 
     <label for="bot_name">Chatbot Name:</label>
     <input type="text" id="bot_name" name="bot_name" placeholder="e.g. SEEP" value="{{ bot_name }}" required>


### PR DESCRIPTION
## Summary
- create `/embed-instructions` route to show script snippet
- redirect setup completion to the new instructions page
- add `templates/embed_instructions.html`
- clean unused success message in setup template

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68507dea14d08332b81b50bf4c5a1114