### PR TITLE
Add embed instructions page

### DIFF
--- a/templates/embed_instructions.html
+++ b/templates/embed_instructions.html
@@ -30,6 +30,8 @@
       border-radius: 5px;
       font-family: monospace;
       word-break: break-all;
+      border: 1px solid #ccc;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.05);
     }
     button {
       margin-top: 10px;
@@ -46,7 +48,8 @@
 <body>
   <div class="box">
     <h1>🎉 Setup Complete</h1>
-    <p>Paste this into your Shopify <code>theme.liquid</code> file before &lt;/body&gt;:</p>
+    <h2>Add SEEP Assistant to your store</h2>
+    <p>Paste the code below into your Shopify <code>theme.liquid</code> file before &lt;/body&gt;:</p>
     <code id="snippet">&lt;script src="https://noble-server.onrender.com/widget.js?shop={{ shopify_domain }}" async&gt;&lt;/script&gt;</code>
     <button onclick="copy()">Copy to Clipboard</button>
   </div>


### PR DESCRIPTION
## Summary
- show embed instructions after setup
- style the embed snippet with a border and shadow
- provide copyable script tag for store owners

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507f969adc83328e728509cf8c36cb