### PR TITLE
Add temporary billing fallbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -420,6 +420,12 @@ def plan_status() -> dict | None:
 @app.route("/billing", methods=["GET", "POST"])
 def billing() -> Response:
     """Trigger Shopify billing or show plan selection."""
+    # TEMPORARY — for demo and submission purposes only
+    if "shopify_domain" not in session:
+        session["shopify_domain"] = "test-shop.myshopify.com"
+
+    if "access_token" not in session:
+        session["access_token"] = "fake_token_123"
     shop = session.get("shopify_domain")
     token = session.get("access_token")
     if not shop or not token:
@@ -470,8 +476,10 @@ def billing() -> Response:
 @app.route("/billing/confirm")
 def billing_confirm() -> Response:
     """Handle Shopify charge confirmation callback."""
-    shop = request.args.get("shop") or session.get("shopify_domain")
-    token = session.get("access_token")
+    # TEMP fallback for charge confirmation step
+    shop = session.get("shopify_domain", "test-shop.myshopify.com")
+    token = session.get("access_token", "fake_token_123")
+    shop = request.args.get("shop") or shop
     if not shop or not token:
         return render_template("error.html", message="Missing Shopify credentials. Please log in again.")
 


### PR DESCRIPTION
## Summary
- insert demo credentials on billing route if not present
- default to demo credentials in billing confirmation route

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6850afdbdd748332b1dfd3a5b3ce0d90