### PR TITLE
Add help documentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,6 +156,12 @@ def health() -> tuple[str, int]:
     return "OK", 200
 
 
+@app.route("/help")
+def help_page() -> str:
+    """Render the help documentation."""
+    return render_template("help.html")
+
+
 @app.route("/setup", methods=["GET", "POST"])
 def setup() -> str:
     guard = require_billing()

--- a/templates/billing_select.html
+++ b/templates/billing_select.html
@@ -96,7 +96,7 @@
 <body>
   <div class="branding">
     <span>SEEP Assistant</span>
-    <a href="#">Help</a>
+    <a href="/help" class="help-button">Help</a>
   </div>
   {% if message %}
     <div class="error">{{ message }}</div>

--- a/templates/error.html
+++ b/templates/error.html
@@ -39,7 +39,7 @@
 <body>
   <div class="branding">
     <span>SEEP Assistant</span>
-    <a href="#">Help</a>
+    <a href="/help" class="help-button">Help</a>
   </div>
   <div class="message">
     <p>{{ message }}</p>

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SEEP Help</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0 auto;
+      padding: 20px;
+      max-width: 800px;
+      line-height: 1.6;
+    }
+    h1 {
+      color: #005b96;
+    }
+    pre {
+      background: #f5f5f5;
+      padding: 10px;
+      border-radius: 5px;
+      overflow-x: auto;
+      margin: 10px 0;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #ccc;
+      margin: 40px 0;
+    }
+    section {
+      margin-bottom: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>SEEP Assistant Help</h1>
+
+  <section>
+    <h2>How to Add SEEP to Your Shopify Store</h2>
+    <ol>
+      <li>Log into your Shopify Admin</li>
+      <li>Go to <em>Online Store → Themes</em></li>
+      <li>Click <em>Actions → Edit Code</em></li>
+      <li>Under the <em>Layout</em> folder, open <code>theme.liquid</code></li>
+      <li>Scroll to the bottom of the file, just above <code>&lt;/body&gt;</code></li>
+      <li>Paste the script:</li>
+    </ol>
+    <pre><code>&lt;script src="https://noble-server.onrender.com/widget.js?shop=your-shop.myshopify.com" async&gt;&lt;/script&gt;</code></pre>
+    <ol start="7">
+      <li>Click Save</li>
+    </ol>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>How to Find Your Shopify Domain</h2>
+    <p>Look at the URL when logged into Shopify, it’s usually:<br>
+    <code>your-store.myshopify.com</code></p>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>How to Get Your Storefront Access Token</h2>
+    <ol>
+      <li>In Shopify Admin, go to Apps → Develop Apps</li>
+      <li>Click Create App</li>
+      <li>Name it “SEEP Assistant”</li>
+      <li>Go to Configuration → Storefront API</li>
+      <li>Add the following access scope:<br><strong>read_products</strong></li>
+      <li>Save and Install the app</li>
+      <li>Shopify will generate a token — copy and paste this into SEEP</li>
+    </ol>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>Need Help?</h2>
+    <p>Email us at:<br>
+    <a href="mailto:info@seep.to">info@seep.to</a></p>
+  </section>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,7 @@
 <body>
   <div class="branding">
     <span>SEEP Assistant</span>
-    <a href="#">Help</a>
+    <a href="/help" class="help-button">Help</a>
   </div>
   <div class="snippet">
     Embed in your theme:

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -72,7 +72,7 @@
 <body>
   <div class="branding">
     <span>SEEP Assistant</span>
-    <a href="#">Help</a>
+    <a href="/help" class="help-button">Help</a>
   </div>
 
   <form method="POST">


### PR DESCRIPTION
## Summary
- add `/help` page route
- create new help page template
- link help button to the new page throughout the UI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b3dde8b48332a9bb68b7707e3ae3