### PR TITLE
Add privacy page and footer links

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,6 +162,12 @@ def help_page() -> str:
     return render_template("help.html")
 
 
+@app.route("/privacy")
+def privacy() -> str:
+    """Show the privacy policy."""
+    return render_template("privacy.html")
+
+
 @app.route("/setup", methods=["GET", "POST"])
 def setup() -> str:
     guard = require_billing()

--- a/templates/billing_select.html
+++ b/templates/billing_select.html
@@ -130,5 +130,8 @@
     </div>
   {% endfor %}
   </div>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -58,5 +58,8 @@
     };
   </script>
   <script src="{{ url_for('static', filename='seep.js') }}"></script>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/embed_instructions.html
+++ b/templates/embed_instructions.html
@@ -59,5 +59,8 @@
       navigator.clipboard.writeText(text);
     }
   </script>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/error.html
+++ b/templates/error.html
@@ -44,5 +44,8 @@
   <div class="message">
     <p>{{ message }}</p>
   </div>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/help.html
+++ b/templates/help.html
@@ -80,5 +80,8 @@
     <p>Email us at:<br>
     <a href="mailto:info@seep.to">info@seep.to</a></p>
   </section>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,5 +133,8 @@
     };
   </script>
   <script src="{{ url_for('static', filename='seep.js') }}"></script>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Seep AI Sales Assistant</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 20px;
+      line-height: 1.6;
+    }
+    h1 { color: #005b96; }
+    footer {
+      text-align: center;
+      margin-top: 40px;
+      font-size: 0.9em;
+    }
+    a { color: #005b96; }
+  </style>
+</head>
+<body>
+  <h1>Seep AI Sales Assistant Privacy Policy</h1>
+  <p>Effective Date: June 2024</p>
+  <p>Seep AI Sales Assistant ("the App") is provided by Seep Tech for Shopify merchants. This policy explains how we handle information collected through the App.</p>
+  <h2>Information We Collect</h2>
+  <ul>
+    <li>Store domain and public shop details</li>
+    <li>Product information needed to answer customer questions</li>
+    <li>Messages sent by visitors through the chat widget</li>
+  </ul>
+  <p>No payment data or other sensitive personal information is collected.</p>
+  <h2>How We Use Your Information</h2>
+  <p>The data we collect is used to operate the App, answer customer questions and suggest products on your storefront. We may also use aggregate, non-personal data to improve our services.</p>
+  <h2>Data Storage</h2>
+  <p>All information is stored securely in Canada. We do not sell or share your data with third parties.</p>
+  <h2>Your Rights</h2>
+  <p>You may request deletion of your stored data at any time by emailing us.</p>
+  <h2>Contact</h2>
+  <p>If you have any questions about this policy, please contact Seep Tech at <a href="mailto:infor@seep.to">infor@seep.to</a>.</p>
+  <footer>
+    <a href="/">Back to Home</a>
+  </footer>
+</body>
+</html>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -93,6 +93,9 @@
 
     <button type="submit">Save and Continue</button>
   </form>
+  <footer style="text-align:center; padding:20px; font-size:0.9em;">
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new `privacy.html` template with Seep Tech policy
- create `/privacy` route in Flask app
- show a **Privacy Policy** link in the footer of each page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6852870cb7d48332932ba46e38b9aa45