### PR TITLE
Update pricing plans

### DIFF
--- a/templates/billing_select.html
+++ b/templates/billing_select.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Choose a SEEP Plan</title>
+  <title>Choose a Plan</title>
   <style>
     body {
       margin: 0;
@@ -102,33 +102,21 @@
     <div class="error">{{ message }}</div>
   {% endif %}
   <h1>SEEP Assistant</h1>
-  <h2>Choose a SEEP Plan</h2>
-  <h2>Choose a flexible plan. Save more with longer commitments.</h2>
+  <h2>Pro Plan</h2>
+  <p style="text-align:center;">7-day free trial. $19.99/month or $159.92/year (save ~33%).</p>
   {% if session.billing_active %}
-    <p style="text-align:center;"><strong>Current Plan:</strong> {{ session.plan_name or 'SEEP Assistant Plan' }}</p>
+    <p style="text-align:center;"><strong>Current Plan:</strong> {{ session.plan_name or 'Pro Plan' }}</p>
   {% endif %}
-  {% set order = ['monthly', '3m', '6m', '12m'] %}
   <div class="plans">
-  {% for key in order %}
-    {% set info = plans[key] %}
     <div class="plan">
-      <h3>{{ info.name }}</h3>
-      {% if key == '12m' %}
-        <div class="badge">Recommended</div>
-      {% endif %}
-      {% if key == 'monthly' %}
-        <p>Free 7-day trial, then $14.99 for 30 days → $19.99/month thereafter</p>
-        <span class="label green">Cancel Anytime</span>
-      {% else %}
-        <p>${{ '%.2f'|format(info.monthly_price) }}/month billed monthly</p>
-        <span class="label red">Commitment Plan – Cannot Cancel Early</span>
-      {% endif %}
+      <h3>Pro Plan</h3>
+      <p>$19.99/mo or $159.92/year after trial</p>
+      <span class="label green">Cancel Anytime</span>
       <form method="post" action="{{ url_for('billing') }}">
-        <input type="hidden" name="plan" value="{{ key }}">
+        <input type="hidden" name="plan" value="pro_plan">
         <button type="submit">Subscribe Now</button>
       </form>
     </div>
-  {% endfor %}
   </div>
   <footer style="text-align:center; padding:20px; font-size:0.9em;">
     <a href="/privacy">Privacy Policy</a>


### PR DESCRIPTION
## Summary
- simplify pricing options to a single `pro_plan`
- display the new plan on the billing page
- activate `pro_plan` on confirmation and redirect to `/`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685293167fa08332bd38997deb978cf1